### PR TITLE
adds support for slh-dsa-sha2-128-s

### DIFF
--- a/__tests__/address.test.ts
+++ b/__tests__/address.test.ts
@@ -21,6 +21,8 @@ describe('PQ Address roundtrip', () => {
   const MlDsaPublicKey =
     'e+ffcul9XkuQCkiCEYX2ES6KMGJ9c7+Z0PFfhnJRckbaHzh4EH9hcEkUoFZ4gK2ta6/xPzgxB1yTT92wPZw8SmrK3DeLMz9mkst0IWkSzJ/TPPHRcSYJekO+CLV8k7uXsGSSoK4fbLqkX8leQFMCzjzRYg06zb3SD7iQwK3O8dP2WWLa9PkBMl1LECCBtTHrxoqyYtKopNbn3wICOOxI1jjTTL46AZnE6Vw2vQdLB/Qg59Pq6su8P3zEqBbsVPwPpT9ZbBNCHE+puWjdYnOfttj6DZ748CRHibQ9WTkH+VpxssIxU62nsYes/fV85nDozwddZggZoLfRsmSlG1Yz6h4m5hMMu9Nku9myTTw4UCiGSxZmad+yIjl7hh6J3wDaLMDA6SXajLSXTk2RwmnsEUlYs+uXS6Wj5wzg+bLQDQVMkU+doOf4vPTArf4uwzJdZ9Ghp8vjHd+rQgKjuo+Hy+HWz4JgvaQXlln+3yF0eY4/v01Bhe8BwVCbFZX8ts2Ay53gJmZEtsnXw3d5xedAMO9LJt4UqwovnmWCuApzAG9jyvG3Wxxe572E725S4vLtgnESzfrsD3wWo/A0oP+wk4oOFjhRDdVwHzwBDiHPhl43b/lt6omQuxK+xF0BJ77X/VhAoCx5zwIQ1GnmtXmP5xqx8f+e9ceFWNSxBPVKakKx/BveCxF1uOLc7DZUFLDVxRBURiF4BQX/670+FaYF2BWS3XtxfCqxaCz3F177qUev3pYuwpvSIj6WNSmU8uyxvibSzvYtA50gQtznTfteWja14B8AB+rgagz5nEzRzO7u1+QmxbdvEyBKvmWzNtnvsNqee4LhU9sl6rPdyUScmDrCPVLiPhrqY/sBVfxzX6z40suflYFPYU+fE6lApXnpyDB8he25DmnmPYTEsCq9d2uYaYTSBAgeir0qi9Jnjj/mcJ/3sNwwTlh7Tp6ahJlqWEUJ4myGxcHEesgWAeIrqJ6bhHTxP1n+do4ffry4CMcAjoAPAwYY0JUTYANy722LbOgiN+z5KUryC/MYjw/azOHFcpYjsGR60fARG03yVBgNBuD5okkmxtrAGdS4w85UDMAa/dwobUI5bdigFHP0Av6hHQ5uxeaxt1gAO53veGmA8aIOidhtZyHhlv+ANl9VYyZMOdPP1DjBTd8AQTIGR2JglmGzE8/00Ndx736MNdVzxNG0iKOvLlgl3cd1cEjW6hfC47juSDCgZTs9oPeo2mr1qvtak7zVd/yByjP9KHh0mjCi3cZDButaTe/oic4bdf24xQDtahSEJpAf49i9gzIpqxG92pyM7HRaVSvScFmCNnNKLJSDCeYw4+zlU+jawGKPjX6ebFDGFV1gNiPvkZdYd/5UXFwpHt5saj/Lgfoe/BtJWUx53TNkYlTNytflgV/ssFo8k9aYlIq2SDDKeZdlZexeNJOvhr8yntOQzLK6WWVONUgilTFNKX3+NQTmMR1LhA7VSP17+/3NjM0wEaz/JpKRoqMMvrgzl2A/6s019UMoT81hGXNtk9Ed8vxtdeNi1BC+SHWWyazundxXMQ4/gD7PnJXQJduz0QZ8quxRQZZTn+u+t1hKyMQikRKqephJaIQv9NLnKffPncEii9ukfRuLLCy7hPFuAho1Bfgi6rJMN0AxlX9URe6LB6vjLMNdTvWVqCHtBvay4scJg58my00razBF8BhQe7db+UJiv5JwADSJ2fwO/oooReksH3Sv1U4UOx5Y7kK8bbChFg==';
 
+  const SlhDsaPublicKey = 'Wi6WLwN39BUnK7X4gkIG101E2zMZWNAVdOsrG8/IxN4=';
+
   it('mainnet MLDSA44', () => {
     const params = {
       network: Network.Mainnet,
@@ -33,7 +35,7 @@ describe('PQ Address roundtrip', () => {
     expect(addr).toEqual(
       'yp1qpqg39uw700gcctpahe650p9zlzpnjt60cpz09m4kx7ncz8922635hs5cdx7q'
     );
-    expect(addr.startsWith('yp1')).toBe(true);
+    expect(addr.startsWith('yp')).toBe(true);
 
     const decoded = decodeAddress(addr);
     expect(decoded.network).toBe('mainnet');
@@ -58,7 +60,7 @@ describe('PQ Address roundtrip', () => {
     expect(addr).toEqual(
       'rh1qpqg39uw700gcctpahe650p9zlzpnjt60cpz09m4kx7ncz8922635hsmmfzpd'
     );
-    expect(addr.startsWith('rh1')).toBe(true);
+    expect(addr.startsWith('rh')).toBe(true);
 
     const decoded = decodeAddress(addr);
     expect(decoded.network).toBe('testnet');
@@ -68,6 +70,56 @@ describe('PQ Address roundtrip', () => {
     expect(decoded.pubkeyHash).toEqual(hasher.digest(params.pubkeyBytes));
     expect(decoded.toString()).toEqual(
       'rh1qpqg39uw700gcctpahe650p9zlzpnjt60cpz09m4kx7ncz8922635hsmmfzpd'
+    );
+  });
+
+  it('mainnet SLHDSASHA2S128', () => {
+    const params = {
+      network: Network.Mainnet,
+      version: Version.V1,
+      pubkeyType: PubKeyType.SlhDsaSha2S128,
+      pubkeyBytes: base64ToBytes(SlhDsaPublicKey)
+    };
+
+    const addr = encodeAddress(params);
+    expect(addr).toEqual(
+      'yp1qpq3z7j5vfjd9y5vlc86al02ujud4tynj73rahcdaa9cdgu47matt5smc3rlz'
+    );
+    expect(addr.startsWith('yp')).toBe(true);
+
+    const decoded = decodeAddress(addr);
+    expect(decoded.network).toBe('mainnet');
+    expect(decoded.version).toBe('V1');
+    expect(decoded.pubkeyType).toBe('SlhDsaSha2S128');
+
+    expect(decoded.pubkeyHash).toEqual(hasher.digest(params.pubkeyBytes));
+    expect(decoded.toString()).toEqual(
+      'yp1qpq3z7j5vfjd9y5vlc86al02ujud4tynj73rahcdaa9cdgu47matt5smc3rlz'
+    );
+  });
+
+  it('testnet SLHDSASHA2S128', () => {
+    const params = {
+      network: Network.Testnet,
+      version: Version.V1,
+      pubkeyType: PubKeyType.SlhDsaSha2S128,
+      pubkeyBytes: base64ToBytes(SlhDsaPublicKey)
+    };
+
+    const addr = encodeAddress(params);
+    expect(addr).toEqual(
+      'rh1qpq3z7j5vfjd9y5vlc86al02ujud4tynj73rahcdaa9cdgu47matt5s5m48q0'
+    );
+    expect(addr.startsWith('rh')).toBe(true);
+
+    const decoded = decodeAddress(addr);
+    expect(decoded.network).toBe('testnet');
+    expect(decoded.version).toBe('V1');
+    expect(decoded.pubkeyType).toBe('SlhDsaSha2S128');
+
+    expect(decoded.pubkeyHash).toEqual(hasher.digest(params.pubkeyBytes));
+    expect(decoded.toString()).toEqual(
+      'rh1qpq3z7j5vfjd9y5vlc86al02ujud4tynj73rahcdaa9cdgu47matt5s5m48q0'
     );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,12 +33,16 @@ export function versionFromCode(code: number): Version {
 /** 0x40..=0xFF (192 slots) */
 export enum PubKeyType {
   // eslint-disable-next-line no-unused-vars
-  MlDsa44 = 0x40
+  MlDsa44 = 0x40,
+  // eslint-disable-next-line no-unused-vars
+  SlhDsaSha2S128 = 0x41
 }
 export function pubKeyTypeFromCode(code: number): PubKeyType {
   switch (code) {
     case PubKeyType.MlDsa44:
       return PubKeyType.MlDsa44;
+    case PubKeyType.SlhDsaSha2S128:
+      return PubKeyType.SlhDsaSha2S128;
     default:
       throw new UnknownPubKeyTypeError(code);
   }
@@ -48,6 +52,8 @@ function getPubkeyLength(type: PubKeyType): number {
   switch (type) {
     case PubKeyType.MlDsa44:
       return 1312;
+    case PubKeyType.SlhDsaSha2S128:
+      return 32;
     default:
       throw new UnknownPubKeyTypeError(type);
   }


### PR DESCRIPTION
# Why

We want to support the NIST approved DSA `SLH-DSA SHA2 128 s`. This PR adds support for this.

# How

Updates the supported public keys that our encoder and decoder supports

# Security changes

Nil

# Testing

Adds same test coverage as `ML DSA 44`